### PR TITLE
[Quick FIx] Add availability zone data source and assign to subnet

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -11,6 +11,11 @@ provider "aws" {
   region = var.aws_region
 }
 
+# Fetch availability zones
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 # Create a VPC
 resource "aws_vpc" "ctf_vpc" {
   cidr_block = "10.0.0.0/16"
@@ -33,6 +38,7 @@ resource "aws_internet_gateway" "ctf_igw" {
 resource "aws_subnet" "ctf_subnet" {
   vpc_id     = aws_vpc.ctf_vpc.id
   cidr_block = "10.0.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "CTF Lab Subnet"


### PR DESCRIPTION
I tried to spin up the environment for the challenge in eu-west-2 region in AWS cloud, if an Availability zone is not specified in the subnet, a random az is assigned. Now issue with this is that the `t2.micro`  EC2 instance type is not available in all AZz which poses a problem and will throw the terraform error in the attached photo. 

This pull request tends to solve this problem by fetching all the AZs in a region and selecting the first one for example (eu-west-2a). I'm sure the first AZ in every region should have the `t2.micro` instance type.

![Screenshot 2025-02-22 095149](https://github.com/user-attachments/assets/561c0a95-2ba2-434d-b00f-e36f67dd1405)
