### PR TITLE
Feature: Persistent script upgrade

### DIFF
--- a/aws/ctf_setup.sh
+++ b/aws/ctf_setup.sh
@@ -170,7 +170,7 @@ while true; do
 done
 EOF
 sudo chmod +x /usr/local/bin/secret_service.sh
-sudo nohup /usr/local/bin/secret_service.sh &
+#sudo nohup /usr/local/bin/secret_service.sh &
 
 # Challenge 7: Encoding challenge
 echo "CTF{decoding_master}" | base64 | base64 > /home/ctf_user/ctf_challenges/encoded_flag.txt
@@ -197,7 +197,7 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/monitor_directory.sh
-sudo nohup /usr/local/bin/monitor_directory.sh > /var/log/monitor_directory.log 2>&1 &
+#sudo nohup /usr/local/bin/monitor_directory.sh > /var/log/monitor_directory.log 2>&1 &
 
 # Challenge 11: Web Configuration
 sudo mkdir -p /var/www/html
@@ -217,7 +217,60 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/ping_message.sh
-sudo nohup /usr/local/bin/ping_message.sh > /var/log/ping_message.log 2>&1 &
+#sudo nohup /usr/local/bin/ping_message.sh > /var/log/ping_message.log 2>&1 &
+
+# Systemd service for secret_service.sh
+cat > /etc/systemd/system/secret_service.service << 'EOF'
+[Unit]
+Description=CTF Secret Service Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/secret_service.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Systemd service for monitor_directory.sh
+cat > /etc/systemd/system/monitor_directory.service << 'EOF'
+[Unit]
+Description=CTF Monitor Directory Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/monitor_directory.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Systemd service for ping_message.sh
+cat > /etc/systemd/system/ping_message.service << 'EOF'
+[Unit]
+Description=CTF Ping Message Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ping_message.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Reload systemd and enable/start services
+sudo systemctl daemon-reload
+sudo systemctl enable secret_service monitor_directory ping_message
+sudo systemctl start secret_service monitor_directory ping_message
 
 # Set permissions
 sudo chown -R ctf_user:ctf_user /home/ctf_user/ctf_challenges

--- a/aws/ctf_setup.sh
+++ b/aws/ctf_setup.sh
@@ -170,7 +170,6 @@ while true; do
 done
 EOF
 sudo chmod +x /usr/local/bin/secret_service.sh
-#sudo nohup /usr/local/bin/secret_service.sh &
 
 # Challenge 7: Encoding challenge
 echo "CTF{decoding_master}" | base64 | base64 > /home/ctf_user/ctf_challenges/encoded_flag.txt
@@ -197,7 +196,6 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/monitor_directory.sh
-#sudo nohup /usr/local/bin/monitor_directory.sh > /var/log/monitor_directory.log 2>&1 &
 
 # Challenge 11: Web Configuration
 sudo mkdir -p /var/www/html
@@ -217,7 +215,6 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/ping_message.sh
-#sudo nohup /usr/local/bin/ping_message.sh > /var/log/ping_message.log 2>&1 &
 
 # Systemd service for secret_service.sh
 cat > /etc/systemd/system/secret_service.service << 'EOF'

--- a/azure/ctf_setup.sh
+++ b/azure/ctf_setup.sh
@@ -163,7 +163,7 @@ while true; do
 done
 EOF
 sudo chmod +x /usr/local/bin/secret_service.sh
-sudo nohup /usr/local/bin/secret_service.sh &
+#sudo nohup /usr/local/bin/secret_service.sh &
 
 # Challenge 7: Encoding challenge
 echo "CTF{decoding_master}" | base64 | base64 > /home/ctf_user/ctf_challenges/encoded_flag.txt
@@ -186,11 +186,11 @@ DIRECTORY="/home/ctf_user/ctf_challenges"
 inotifywait -m -e create --format '%f' "$DIRECTORY" | while read FILE
 do
     echo "A new file named $FILE has been added to $DIRECTORY. Here is your flag: CTF{network_copy}" | wall
-done
+done &
 EOF
 
 sudo chmod +x /usr/local/bin/monitor_directory.sh
-sudo nohup /usr/local/bin/monitor_directory.sh > /var/log/monitor_directory.log 2>&1 &
+#sudo nohup /usr/local/bin/monitor_directory.sh > /var/log/monitor_directory.log 2>&1 &
 
 # Challenge 11: Web Configuration
 sudo mkdir -p /var/www/html
@@ -210,8 +210,64 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/ping_message.sh
-sudo nohup /usr/local/bin/ping_message.sh > /var/log/ping_message.log 2>&1 &
+#sudo nohup /usr/local/bin/ping_message.sh > /var/log/ping_message.log 2>&1 &
 
+# ...existing code...
+
+# Systemd service for secret_service.sh
+cat > /etc/systemd/system/secret_service.service << 'EOF'
+[Unit]
+Description=CTF Secret Service Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/secret_service.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Systemd service for monitor_directory.sh
+cat > /etc/systemd/system/monitor_directory.service << 'EOF'
+[Unit]
+Description=CTF Monitor Directory Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/monitor_directory.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Systemd service for ping_message.sh
+cat > /etc/systemd/system/ping_message.service << 'EOF'
+[Unit]
+Description=CTF Ping Message Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ping_message.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Reload systemd and enable/start services
+sudo systemctl daemon-reload
+sudo systemctl enable secret_service monitor_directory ping_message
+sudo systemctl start secret_service monitor_directory ping_message
+
+# ...existing code...
 # Set permissions
 sudo chown -R ctf_user:ctf_user /home/ctf_user/ctf_challenges
 

--- a/azure/ctf_setup.sh
+++ b/azure/ctf_setup.sh
@@ -163,7 +163,6 @@ while true; do
 done
 EOF
 sudo chmod +x /usr/local/bin/secret_service.sh
-#sudo nohup /usr/local/bin/secret_service.sh &
 
 # Challenge 7: Encoding challenge
 echo "CTF{decoding_master}" | base64 | base64 > /home/ctf_user/ctf_challenges/encoded_flag.txt
@@ -186,11 +185,10 @@ DIRECTORY="/home/ctf_user/ctf_challenges"
 inotifywait -m -e create --format '%f' "$DIRECTORY" | while read FILE
 do
     echo "A new file named $FILE has been added to $DIRECTORY. Here is your flag: CTF{network_copy}" | wall
-done &
+done
 EOF
 
 sudo chmod +x /usr/local/bin/monitor_directory.sh
-#sudo nohup /usr/local/bin/monitor_directory.sh > /var/log/monitor_directory.log 2>&1 &
 
 # Challenge 11: Web Configuration
 sudo mkdir -p /var/www/html
@@ -210,9 +208,7 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/ping_message.sh
-#sudo nohup /usr/local/bin/ping_message.sh > /var/log/ping_message.log 2>&1 &
 
-# ...existing code...
 
 # Systemd service for secret_service.sh
 cat > /etc/systemd/system/secret_service.service << 'EOF'
@@ -267,7 +263,6 @@ sudo systemctl daemon-reload
 sudo systemctl enable secret_service monitor_directory ping_message
 sudo systemctl start secret_service monitor_directory ping_message
 
-# ...existing code...
 # Set permissions
 sudo chown -R ctf_user:ctf_user /home/ctf_user/ctf_challenges
 

--- a/gcp/ctf_setup.sh
+++ b/gcp/ctf_setup.sh
@@ -169,7 +169,6 @@ while true; do
 done
 EOF
 sudo chmod +x /usr/local/bin/secret_service.sh
-sudo nohup /usr/local/bin/secret_service.sh &
 
 # Challenge 7: Encoding challenge
 echo "CTF{decoding_master}" | base64 | base64 > /home/ctf_user/ctf_challenges/encoded_flag.txt
@@ -196,7 +195,6 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/monitor_directory.sh
-sudo nohup /usr/local/bin/monitor_directory.sh > /var/log/monitor_directory.log 2>&1 &
 
 # Challenge 11: Web Configuration
 sudo mkdir -p /var/www/html
@@ -216,7 +214,59 @@ done
 EOF
 
 sudo chmod +x /usr/local/bin/ping_message.sh
-sudo nohup /usr/local/bin/ping_message.sh > /var/log/ping_message.log 2>&1 &
+
+# Systemd service for secret_service.sh
+cat > /etc/systemd/system/secret_service.service << 'EOF'
+[Unit]
+Description=CTF Secret Service Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/secret_service.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Systemd service for monitor_directory.sh
+cat > /etc/systemd/system/monitor_directory.service << 'EOF'
+[Unit]
+Description=CTF Monitor Directory Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/monitor_directory.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Systemd service for ping_message.sh
+cat > /etc/systemd/system/ping_message.service << 'EOF'
+[Unit]
+Description=CTF Ping Message Challenge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ping_message.sh
+Restart=always
+User=ctf_user
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Reload systemd and enable/start services
+sudo systemctl daemon-reload
+sudo systemctl enable secret_service monitor_directory ping_message
+sudo systemctl start secret_service monitor_directory ping_message
 
 # Set permissions
 sudo chown -R ctf_user:ctf_user /home/ctf_user/ctf_challenges


### PR DESCRIPTION
## Scripts on Boot
Exercise scripts have been made into services. 

This allows the service to be started at boot, this will enable the user to shutdown and or restart their VMs.

### Scripts modified
Exersises 6, 11. and 12

All lines with `sudo nohup` have been deleted and added to a service near the bottom of the ctf_setup.sh script.