### PR TITLE
Added timeout for the remote-exec in GCP

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -112,6 +112,7 @@ resource "null_resource" "wait_for_setup" {
       host     = google_compute_instance.ctf_instance.network_interface[0].access_config[0].nat_ip
       user     = "ctf_user"
       password = "CTFpassword123!"
+      timeout  = "5m"
     }
     
     inline = [


### PR DESCRIPTION
This pull request makes a minor update to the SSH provisioner configuration in the `gcp/main.tf` file. The change sets a timeout for the SSH connection to improve reliability during setup.