### PR TITLE
Add 10m SSH timeout to fix remote-exec provisioner race condition

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -143,6 +143,7 @@ resource "null_resource" "wait_for_setup" {
       host     = aws_instance.ctf_instance.public_ip
       user     = "ctf_user"
       password = "CTFpassword123!"
+      timeout  = "10m"
     }
     
     inline = [

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -139,6 +139,7 @@ resource "null_resource" "wait_for_setup" {
       host     = azurerm_linux_virtual_machine.ctf_vm.public_ip_address
       user     = "ctf_user"
       password = "CTFpassword123!"
+      timeout  = "10m"
     }
     
     inline = [

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -115,7 +115,7 @@ resource "null_resource" "wait_for_setup" {
       host     = google_compute_instance.ctf_instance.network_interface[0].access_config[0].nat_ip
       user     = "ctf_user"
       password = "CTFpassword123!"
-      timeout  = "5m"
+      timeout  = "10m"
     }
     
     inline = [


### PR DESCRIPTION
The user_data script takes time to enable password authentication. Without a timeout, Terraform's remote-exec fails because SSH password auth isn't enabled yet when it first tries to connect.