### PR TITLE
Add EC2 start/stop instance control using Terraform

### DIFF
--- a/aws/.gitignore
+++ b/aws/.gitignore
@@ -1,4 +1,4 @@
-# Local .terraform directories
+i# Local .terraform directories
 **/.terraform/*
 
 # .tfstate files
@@ -37,4 +37,9 @@ override.tf.json
 terraform.rc
 
 # Ignore terraform.lock.hcl file
+
 .terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform practise/
+

--- a/aws/.gitignore
+++ b/aws/.gitignore
@@ -1,4 +1,4 @@
-i# Local .terraform directories
+# Local .terraform directories
 **/.terraform/*
 
 # .tfstate files

--- a/aws/.gitignore
+++ b/aws/.gitignore
@@ -39,7 +39,3 @@ terraform.rc
 # Ignore terraform.lock.hcl file
 
 .terraform.lock.hcl
-terraform.tfstate
-terraform.tfstate.backup
-terraform practise/
-

--- a/aws/README.md
+++ b/aws/README.md
@@ -63,4 +63,20 @@ If problems persist, please open an issue in this repository.
 
 ## Security Note
 
+## EC2 Instance Control
+
+You can control the EC2 instance lifecycle (stop/start) using Terraform.
+
+### Stop the EC2 instance
+```bash
+terraform apply -target=null_resource.stop_instance
+
+Add this:
+
+```md
+### Start the EC2 instance
+```bash
+terraform apply -target=null_resource.start_instance
+
+
 This lab uses password authentication for simplicity. In production, use key-based authentication.

--- a/aws/README.md
+++ b/aws/README.md
@@ -59,6 +59,23 @@ terraform apply \
   -auto-approve
 ```
 
+Note: This module uses an ephemeral public IP. After stopping/starting the instance, public_ip_address may change.
+
+After a restart, check for a new IP.
+
+```sh
+terraform output public_ip_address
+```
+If you see a “Remote host identification has changed” warning after a restart, remove the old key, then reconnect:
+
+```sh
+# 1) Remove the old host key for that IP
+ssh-keygen -R <public_ip>
+
+# 2) Reconnect and accept the new key
+ssh <user>@<public_ip>
+```
+
 ## Cleaning Up
 
 Destroy the resources when you're done to avoid charges:

--- a/aws/README.md
+++ b/aws/README.md
@@ -43,6 +43,22 @@
 
 1. When prompted, enter the password: `CTFpassword123!`
 
+## Starting/Stopping the Lab VM
+
+If you'd like to pause the lab, you can utilize the following commands to start or stop the VM and reduce lab cost:
+
+```sh
+# power off (stop instance)
+terraform apply \
+  -var ctf_instance_state="stopped" \
+  -auto-approve
+
+# power on (start instance)
+terraform apply \
+  -var ctf_instance_state="running" \
+  -auto-approve
+```
+
 ## Cleaning Up
 
 Destroy the resources when you're done to avoid charges:
@@ -62,21 +78,5 @@ Type `yes` when prompted.
 If problems persist, please open an issue in this repository.
 
 ## Security Note
-
-## EC2 Instance Control
-
-You can control the EC2 instance lifecycle (stop/start) using Terraform.
-
-### Stop the EC2 instance
-```bash
-terraform apply -target=null_resource.stop_instance
-
-Add this:
-
-```md
-### Start the EC2 instance
-```bash
-terraform apply -target=null_resource.start_instance
-
 
 This lab uses password authentication for simplicity. In production, use key-based authentication.

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,3 +1,12 @@
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
 # Configure the AWS Provider
 # Define the region variable
 variable "aws_region" {
@@ -183,4 +192,25 @@ resource "null_resource" "wait_for_setup" {
 # Output the public IP of the instance
 output "public_ip_address" {
   value = aws_instance.ctf_instance.public_ip
+}
+# Stop EC2 instance
+resource "null_resource" "stop_instance" {
+  triggers = {
+    instance_id = aws_instance.ctf_instance.id
+  }
+
+  provisioner "local-exec" {
+    command = "aws ec2 stop-instances --instance-ids ${aws_instance.ctf_instance.id}"
+  }
+}
+
+# Start EC2 instance
+resource "null_resource" "start_instance" {
+  triggers = {
+    instance_id = aws_instance.ctf_instance.id
+  }
+
+  provisioner "local-exec" {
+    command = "aws ec2 start-instances --instance-ids ${aws_instance.ctf_instance.id}"
+  }
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -193,24 +193,15 @@ resource "null_resource" "wait_for_setup" {
 output "public_ip_address" {
   value = aws_instance.ctf_instance.public_ip
 }
-# Stop EC2 instance
-resource "null_resource" "stop_instance" {
-  triggers = {
-    instance_id = aws_instance.ctf_instance.id
-  }
-
-  provisioner "local-exec" {
-    command = "aws ec2 stop-instances --instance-ids ${aws_instance.ctf_instance.id}"
-  }
+# Desired state of the EC2 instance
+variable "ctf_instance_state" {
+  description = "Desired state of the EC2 instance (running or stopped)"
+  type        = string
+  default     = "running"
 }
 
-# Start EC2 instance
-resource "null_resource" "start_instance" {
-  triggers = {
-    instance_id = aws_instance.ctf_instance.id
-  }
-
-  provisioner "local-exec" {
-    command = "aws ec2 start-instances --instance-ids ${aws_instance.ctf_instance.id}"
-  }
+# Control EC2 instance state declaratively
+resource "aws_ec2_instance_state" "ctf_instance_state" {
+  instance_id = aws_instance.ctf_instance.id
+  state       = var.ctf_instance_state
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -204,4 +204,7 @@ variable "ctf_instance_state" {
 resource "aws_ec2_instance_state" "ctf_instance_state" {
   instance_id = aws_instance.ctf_instance.id
   state       = var.ctf_instance_state
+
+  # Ensure the instance is fully set up before changing its power state
+  depends_on = [null_resource.wait_for_setup]
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -198,6 +198,11 @@ variable "ctf_instance_state" {
   description = "Desired state of the EC2 instance (running or stopped)"
   type        = string
   default     = "running"
+
+  validation {
+    condition     = contains(["running", "stopped"], var.ctf_instance_state)
+    error_message = "ctf_instance_state must be either \"running\" or \"stopped\"."
+  }
 }
 
 # Control EC2 instance state declaratively


### PR DESCRIPTION
Added Terraform-based EC2 stop/start control using null_resource and AWS CLI.
Updated README with usage instructions.
