### PR TITLE
docs: update verification instructions and clarify token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,9 @@ verify export <your-github-username>
 ```
 
 > [!IMPORTANT]  
-> Enter your GitHub username **exactly** as it appears on GitHub—no `@` symbol, no extra spaces, no special characters. For example: `verify export octocat` not `verify export @octocat`. The verification system will reject tokens with incorrect usernames.
+> Enter your GitHub username **exactly** as it appears on GitHub—no `@` symbol, no extra spaces, no special characters. For example: `verify export octocat` not `verify export @octocat`.
 
-This generates a cryptographically signed token. To verify your completion:
-
-1. Go to [learntocloud.guide/phase2](https://learntocloud.guide/phase2)
-2. Sign in with the **same GitHub account** you used in the export command
-3. Copy **only the token** (the long string of characters between the markers):
-   ```
-   --- BEGIN L2C CTF TOKEN ---
-   eyJwYXlsb2FkIjp7...your-unique-token-here...fQ==
-   --- END L2C CTF TOKEN ---
-   ```
-   > **Copy everything between the markers, but NOT the `--- BEGIN/END ---` lines themselves.**
-4. Paste the token into the verification form
+This generates a cryptographically signed completion token. **Save this token!** A verification system is coming soon where you'll be able to verify your completion. For now, keep your token safe—you'll need it later.
 
 ## Tips
 

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -1,20 +1,22 @@
 # CTF Completion Verification
 
-This document describes how the Learn to Cloud CTF verification token system works and how to implement verification in your application.
+> ⚠️ **NOT YET IMPLEMENTED**: The verification system is not yet available. Users should save their completion tokens for future verification. This document is for **contributors/maintainers** planning the verification system implementation.
+
+This document describes how the Learn to Cloud CTF verification token system works and how to implement verification in a future application.
 
 ## Overview
 
 When users complete all 18 challenges and run `verify export <github_username>`, they receive:
 1. A visual certificate displayed in the terminal
-2. A **signed verification token** they can copy-paste to verify their completion
+2. A **signed verification token** they should save for future verification
 
 ## Security Design
 
-The verification system uses **GitHub OAuth** as the primary security mechanism:
+The planned verification system will use **GitHub OAuth** as the primary security mechanism:
 
 1. **User completes CTF** and runs `verify export <github_username>`
 2. **Token is generated** containing their GitHub username
-3. **User visits verification app** at https://learntocloud.guide/phase2 and signs in with GitHub
+3. **User visits verification app** (URL TBD) and signs in with GitHub
 4. **App verifies**: `token.github_username === OAuth_user.login`
 
 This means:

--- a/ctf_setup.sh
+++ b/ctf_setup.sh
@@ -318,8 +318,7 @@ export_certificate() {
         echo "Usage: verify export <github_username>"
         echo "Example: verify export octocat"
         echo ""
-        echo "⚠️  Use your GitHub username! This will be verified when you"
-        echo "   submit your token at https://learntocloud.guide/phase2"
+        echo "⚠️  Use your exact GitHub username! Save your token for future verification."
         return 1
     fi
     local github_username="$1"
@@ -421,13 +420,11 @@ TOKENEOF
     
     echo ""
     echo "============================================================" | lolcat
-    echo "              🎫 VERIFICATION TOKEN                          " | lolcat  
+    echo "              🎫 COMPLETION TOKEN                             " | lolcat  
     echo "============================================================" | lolcat
     echo ""
-    echo "To verify your completion:"
-    echo "  1. Go to https://learntocloud.guide/phase2"
-    echo "  2. Sign in with GitHub (as: $github_username)"
-    echo "  3. Paste the token below"
+    echo "🔐 Save this token! A verification system is coming soon."
+    echo "   Keep it somewhere safe—you'll need it to verify your completion."
     echo ""
     echo "--- BEGIN L2C CTF TOKEN ---"
     echo "$token"

--- a/verify_token.py
+++ b/verify_token.py
@@ -2,8 +2,11 @@
 """
 CTF Token Verification Script
 
-This script mimics what the verification app at https://learntocloud.guide/phase2
-would do to verify a CTF completion token.
+This script is for contributors/maintainers to test token verification locally.
+It demonstrates what a future verification app would do to verify CTF completion tokens.
+
+NOTE: The verification app is not yet implemented. Users should save their tokens
+for future verification.
 """
 
 import base64


### PR DESCRIPTION
This pull request updates documentation, user messaging, and supporting scripts to clarify that the Learn to Cloud CTF verification system is not yet available. Users are now instructed to save their completion tokens for future verification, and references to the previous verification website have been removed or marked as "TBD." These changes help set expectations for users and contributors until the verification system is implemented.