### PR TITLE
Add frozen CTF timer behavior and docs updates

### DIFF
--- a/.github/skills/ctf-testing/test_ctf_challenges.sh
+++ b/.github/skills/ctf-testing/test_ctf_challenges.sh
@@ -174,6 +174,15 @@ if ! command -v verify &>/dev/null; then
     exit 1
 fi
 
+# Timer should not start before first numeric verify command
+rm -f /var/ctf/ctf_start_time /var/ctf/ctf_end_time
+TIMER_PRESTART_OUT=$(verify time 2>&1) || true
+if echo "${TIMER_PRESTART_OUT}" | grep -q "Timer not started"; then
+    _pass "verify time shows pre-start message"
+else
+    _fail "verify time pre-start behavior incorrect"
+fi
+
 VERIFY_OUTPUT=$(verify 0 "CTF{example}" 2>&1) || true
 if echo "${VERIFY_OUTPUT}" | grep -q "✓"; then
     _pass "verify command accepts example flag"
@@ -181,6 +190,12 @@ else
     _fail "verify command broken - SETUP BUG"
     echo "Cannot continue without working verify command"
     exit 1
+fi
+
+if [[ -f /var/ctf/ctf_start_time ]]; then
+    _pass "Timer starts after first numeric verify command"
+else
+    _fail "Timer did not start after first numeric verify command"
 fi
 
 # ============================================================================
@@ -600,6 +615,15 @@ if echo "${EXPORT_OUT}" | grep -q "BEGIN L2C CTF TOKEN"; then
     fi
 else
     _fail "Export missing token"
+fi
+
+FIRST_TIME_OUT=$(verify time 2>&1) || true
+sleep 2
+SECOND_TIME_OUT=$(verify time 2>&1) || true
+if [[ "${FIRST_TIME_OUT}" == "${SECOND_TIME_OUT}" ]]; then
+    _pass "verify time is frozen after first successful export"
+else
+    _fail "verify time changed after export (freeze failed)"
 fi
 
 # ============================================================================

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ verify export <your-github-username>
 
 Save the token it generates — you'll need it to verify your progress at [learntocloud.guide/phase1](https://learntocloud.guide/phase1).
 
+### Timer and progress behavior
+
+- `verify time` shows **wall clock elapsed time** (not active keyboard time).
+- The timer starts when you first submit a challenge with `verify <number> <flag>`.
+- The timer freezes on your first successful `verify export` after reaching 18/18.
+- Run `verify 0 CTF{example}` early. The example challenge is part of verify progress tracking.
+
 ### Troubleshooting Your Token
 
 Some terminals truncate long lines when copying. If your token isn't being accepted, it may be incomplete. The full token should be around **300+ characters**.

--- a/aws/README.md
+++ b/aws/README.md
@@ -76,6 +76,9 @@ ssh-keygen -R <public_ip>
 ssh <user>@<public_ip>
 ```
 
+> [!NOTE]
+> `verify time` uses wall clock elapsed time. If the lab is stopped before you complete and export, stopped time still counts in elapsed time.
+
 ## Cleaning Up
 
 Destroy the resources when you're done to avoid charges:

--- a/azure/README.md
+++ b/azure/README.md
@@ -55,18 +55,35 @@
 
 If you'd like to pause the lab, you can utilize the following commands to start or stop the VM and reduce lab cost:
 
+To power off the VM:
+
+1. exit from the SSH session:
+
+    ```sh
+    exit
+    ```
+ 2. Use the following commands to power off or on the VM:
 ```sh
 # power off
-terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_off \
-    -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
-    -var az_region="YOUR_AZURE_REGION" \
-    -auto-approve
-# power on
-terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_on \
-    -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
-    -var az_region="YOUR_AZURE_REGION" \
-    -auto-approve
+terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_off 
+3. Type `yes` when prompted.
+
+To power on the VM:
+1. Use the following command to power on the VM:
+```sh
+terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_on 
 ```
+
+1. type `yes` when prompted.
+1. Connect to the VM via SSH:
+    ```sh
+    ssh ctf_user@<public_ip_address>
+    ```
+
+> [!NOTE]
+> `verify time` uses wall clock elapsed time. If the lab is powered off before you complete and export, powered-off time still counts in elapsed time.
+
+
 
 ## Cleaning Up
 

--- a/ctf_setup.sh
+++ b/ctf_setup.sh
@@ -173,6 +173,7 @@ CHALLENGE_HINTS=(
 
 PROGRESS_FILE=/var/ctf/completed_challenges
 START_TIME_FILE=/var/ctf/ctf_start_time
+END_TIME_FILE=/var/ctf/ctf_end_time
 
 check_flag() {
     local challenge_num=$1
@@ -219,14 +220,45 @@ init_timer() {
     fi
 }
 
+get_elapsed_seconds() {
+    if [ ! -f "$START_TIME_FILE" ]; then
+        return 1
+    fi
+
+    local start_time end_time
+    start_time=$(cat "$START_TIME_FILE")
+    if [ -f "$END_TIME_FILE" ]; then
+        end_time=$(cat "$END_TIME_FILE")
+    else
+        end_time=$(date +%s)
+    fi
+
+    echo $((end_time - start_time))
+}
+
+freeze_end_time_on_export() {
+    if [ -f "$END_TIME_FILE" ]; then
+        return
+    fi
+
+    local completed=0
+    if [ -f "$PROGRESS_FILE" ]; then
+        completed=$(sort -u "$PROGRESS_FILE" | wc -l)
+        completed=$((completed-1))
+    fi
+
+    if [ "$completed" -ge 18 ]; then
+        date +%s > "$END_TIME_FILE"
+    fi
+}
+
 show_time() {
     if [ ! -f "$START_TIME_FILE" ]; then
         echo "Timer not started. Complete your first challenge to start the timer."
         return
     fi
-    local start_time=$(cat "$START_TIME_FILE")
-    local current_time=$(date +%s)
-    local elapsed=$((current_time - start_time))
+    local elapsed
+    elapsed=$(get_elapsed_seconds)
     local hours=$((elapsed / 3600))
     local minutes=$(((elapsed % 3600) / 60))
     local seconds=$((elapsed % 60))
@@ -287,12 +319,13 @@ export_certificate() {
         return 1
     fi
     local github_username="$1"
-    
+
+    freeze_end_time_on_export
+
     local completion_time="Unknown"
     if [ -f "$START_TIME_FILE" ]; then
-        local start_time=$(cat "$START_TIME_FILE")
-        local end_time=$(date +%s)
-        local elapsed=$((end_time - start_time))
+        local elapsed
+        elapsed=$(get_elapsed_seconds)
         local hours=$((elapsed / 3600))
         local minutes=$(((elapsed % 3600) / 60))
         completion_time=$(printf "%02d:%02d" $hours $minutes)
@@ -457,10 +490,13 @@ and review your progress.
 
 Usage:
   verify [challenge number] [flag] - Submit flag for verification
-  verify 0 CTF{example} - Example flag
+  verify 0 CTF{example} - Example flag (required)
   verify progress     - Shows your progress
+  verify time         - Shows elapsed wall clock time
 
-  To capture first flag, run: verify 0 CTF{example}
+  Run this first to initialize progress: verify 0 CTF{example}
+  Note: Timer starts on your first challenge submission.
+  It freezes on your first successful verify export after 18/18.
 
 When you complete all challenges, run: verify export <your-github-username>
 Save the token it generates — you'll need it to verify your

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -51,6 +51,10 @@
 
 1. When prompted, enter the password: `CTFpassword123!`
 
+## Timer Behavior
+
+`verify time` uses wall clock elapsed time. The timer starts on your first challenge submission and freezes on your first successful `verify export` after 18/18.
+
 
 ## Cleaning Up
 


### PR DESCRIPTION
- Persist ctf_end_time on first successful export after 18/18
- Reuse frozen elapsed time in verify time and export output
- Clarify example flag and timer behavior in MOTD and READMEs
- Add timer behavior checks to CTF test script

resolves #79 