### PR TITLE
Wait for CTF setup readiness

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -29,22 +29,6 @@
 
     Type `yes` when prompted.
 
-    By default, Terraform uses release mode. The VM downloads the setup package from the latest GitHub Release, verifies its SHA-256 checksum, and runs setup during first boot.
-
-    Maintainers can choose a specific setup release if they need to pin or roll back the setup package:
-
-    ```sh
-    terraform apply -var setup_release_tag="v0.1.0"
-    ```
-
-    If you are testing unmerged local setup changes, run:
-
-    ```sh
-    terraform apply -var use_local_setup=true
-    ```
-
-    Contributor mode uploads your local setup files and uses SSH to run them on the VM.
-
 4. Note the `public_ip_address` output—you'll use this to connect.
 
 ## Accessing the Lab
@@ -120,12 +104,7 @@ Include:
 - `terraform version`
 - `aws sts get-caller-identity` output (no secrets)
 - The exact `terraform apply` error output (redact any secrets)
-- Whether SSH fails or the issue happens after login (e.g., `verify progress`)
-- If SSH works but the lab is not ready, check `/var/log/ctf_setup.log`, `/var/lib/cloud/instance/ctf-setup.done`, `/var/lib/linux-ctfs/setup.done`, and `/var/lib/linux-ctfs/setup.failed`
-
-### Changing Setup Versions
-
-The setup script runs during first boot. If you change `setup_release_tag` after a VM already exists, or if the default `latest` release changes, recreate the VM so first-boot setup runs with the new package.
+- Whether SSH fails or the issue happens after login, such as when running `verify progress`
 
 ## Security Note
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }
 # Configure the AWS Provider
@@ -104,6 +108,28 @@ locals {
     touch "$${DONE_MARKER}"
     rm -f "$${FAILED_MARKER}"
     trap - ERR
+  EOF
+
+  release_readiness_script = <<-EOF
+    set -eu
+    echo "Waiting for CTF setup to finish..."
+    for attempt in $(seq 1 180); do
+      if test -f /var/lib/linux-ctfs/setup.failed; then
+        echo "CTF setup failed. Check /var/log/ctf_setup.log and /var/log/cloud-init-output.log." >&2
+        exit 1
+      fi
+
+      if test -f /var/lib/linux-ctfs/setup.done || test -f /var/lib/cloud/instance/ctf-setup.done || test -f /var/log/setup_complete; then
+        echo "CTF setup is complete."
+        exit 0
+      fi
+
+      echo "CTF setup is still running. Attempt $attempt/180."
+      sleep 10
+    done
+
+    echo "Timed out waiting for CTF setup. Check /var/log/ctf_setup.log and /var/log/cloud-init-output.log." >&2
+    exit 1
   EOF
 }
 
@@ -278,9 +304,31 @@ resource "null_resource" "local_setup" {
   }
 }
 
+resource "null_resource" "release_setup_ready" {
+  count      = var.use_local_setup ? 0 : 1
+  depends_on = [aws_instance.ctf_instance]
+
+  triggers = {
+    instance_id = aws_instance.ctf_instance.id
+  }
+
+  connection {
+    type     = "ssh"
+    host     = aws_instance.ctf_instance.public_ip
+    user     = "ctf_user"
+    password = "CTFpassword123!"
+    timeout  = "30m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [local.release_readiness_script]
+  }
+}
+
 # Output the public IP of the instance
 output "public_ip_address" {
-  value = aws_instance.ctf_instance.public_ip
+  value      = aws_instance.ctf_instance.public_ip
+  depends_on = [null_resource.local_setup, null_resource.release_setup_ready]
 }
 # Desired state of the EC2 instance
 variable "ctf_instance_state" {
@@ -299,5 +347,5 @@ resource "aws_ec2_instance_state" "ctf_instance_state" {
   instance_id = aws_instance.ctf_instance.id
   state       = var.ctf_instance_state
 
-  depends_on = [null_resource.local_setup]
+  depends_on = [null_resource.local_setup, null_resource.release_setup_ready]
 }

--- a/azure/README.md
+++ b/azure/README.md
@@ -37,19 +37,6 @@
 
     Type `yes` when prompted.
 
-    By default, Terraform uses release mode. The VM downloads the setup package from the latest GitHub Release, verifies its SHA-256 checksum, and runs setup during first boot.
-
-    Maintainers can choose a specific setup release if they need to pin or roll back the setup package:
-
-    ```sh
-    terraform apply \
-      -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
-      -var az_region="YOUR_AZURE_REGION" \
-      -var setup_release_tag="v0.1.0"
-    ```
-
-    If you are testing unmerged local setup changes, add `-var use_local_setup=true` to the `terraform apply` command. Contributor mode uploads your local setup files and uses SSH to run them on the VM.
-
 4. Note the `public_ip_address` output—you'll use this to connect.
 
 ## Accessing the Lab
@@ -66,37 +53,32 @@
 
 ## Starting/Stopping the Lab VM
 
-If you'd like to pause the lab, you can utilize the following commands to start or stop the VM and reduce lab cost:
+If you want to pause the lab and reduce cost, use these commands.
 
-To power off the VM:
+Power off the VM:
 
-1. exit from the SSH session:
-
-    ```sh
-    exit
-    ```
- 2. Use the following commands to power off or on the VM:
 ```sh
-# power off
-terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_off 
-3. Type `yes` when prompted.
-
-To power on the VM:
-1. Use the following command to power on the VM:
-```sh
-terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_on 
+terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_off
 ```
 
-1. type `yes` when prompted.
-1. Connect to the VM via SSH:
-    ```sh
-    ssh ctf_user@<public_ip_address>
-    ```
+Type `yes` when prompted.
+
+Power on the VM:
+
+```sh
+terraform apply -invoke=action.azurerm_virtual_machine_power.ctf_power_on
+```
+
+Type `yes` when prompted.
+
+Connect again:
+
+```sh
+ssh ctf_user@<public_ip_address>
+```
 
 > [!NOTE]
 > `verify time` uses wall clock elapsed time. If the lab is powered off before you complete and export, powered-off time still counts in elapsed time.
-
-
 
 ## Cleaning Up
 
@@ -123,12 +105,7 @@ Include:
 - `terraform version`
 - `az account show` output (no secrets)
 - The exact `terraform apply` error output (redact any secrets)
-- Whether SSH fails or the issue happens after login (e.g., `verify progress`)
-- If SSH works but the lab is not ready, check `/var/log/ctf_setup.log`, `/var/lib/cloud/instance/ctf-setup.done`, `/var/lib/linux-ctfs/setup.done`, and `/var/lib/linux-ctfs/setup.failed`
-
-### Changing Setup Versions
-
-The setup script runs during first boot. If you change `setup_release_tag` after a VM already exists, or if the default `latest` release changes, recreate the VM so first-boot setup runs with the new package.
+- Whether SSH fails or the issue happens after login, such as when running `verify progress`
 
 ### VM Size / Capacity Errors
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -110,6 +110,28 @@ locals {
     rm -f "$${FAILED_MARKER}"
     trap - ERR
   EOF
+
+  release_readiness_script = <<-EOF
+    set -eu
+    echo "Waiting for CTF setup to finish..."
+    for attempt in $(seq 1 180); do
+      if test -f /var/lib/linux-ctfs/setup.failed; then
+        echo "CTF setup failed. Check /var/log/ctf_setup.log and /var/log/cloud-init-output.log." >&2
+        exit 1
+      fi
+
+      if test -f /var/lib/linux-ctfs/setup.done || test -f /var/lib/cloud/instance/ctf-setup.done || test -f /var/log/setup_complete; then
+        echo "CTF setup is complete."
+        exit 0
+      fi
+
+      echo "CTF setup is still running. Attempt $attempt/180."
+      sleep 10
+    done
+
+    echo "Timed out waiting for CTF setup. Check /var/log/ctf_setup.log and /var/log/cloud-init-output.log." >&2
+    exit 1
+  EOF
 }
 
 provider "azurerm" {
@@ -301,8 +323,28 @@ resource "null_resource" "local_setup" {
   }
 }
 
+resource "null_resource" "release_setup_ready" {
+  count      = var.use_local_setup ? 0 : 1
+  depends_on = [azurerm_linux_virtual_machine.ctf_vm]
+
+  triggers = {
+    instance_id = azurerm_linux_virtual_machine.ctf_vm.id
+  }
+
+  connection {
+    host     = azurerm_linux_virtual_machine.ctf_vm.public_ip_address
+    user     = "ctf_user"
+    password = "CTFpassword123!"
+    timeout  = "30m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [local.release_readiness_script]
+  }
+}
+
 # Output the public IP address
 output "public_ip_address" {
   value      = azurerm_linux_virtual_machine.ctf_vm.public_ip_address
-  depends_on = [null_resource.local_setup]
+  depends_on = [null_resource.local_setup, null_resource.release_setup_ready]
 }

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -36,20 +36,6 @@
 
     Type `yes` when prompted.
 
-    By default, Terraform uses release mode. The VM downloads the setup package from the latest GitHub Release, verifies its SHA-256 checksum, and runs setup during first boot.
-
-    Maintainers can choose a specific setup release if they need to pin or roll back the setup package:
-
-    ```sh
-    terraform apply \
-      -var gcp_project="YOUR_GCP_PROJECT_ID" \
-      -var gcp_region="YOUR_GCP_REGION" \
-      -var gcp_zone="YOUR_GCP_ZONE" \
-      -var setup_release_tag="v0.1.0"
-    ```
-
-    If you are testing unmerged local setup changes, add `-var use_local_setup=true` to the `terraform apply` command. Contributor mode uploads your local setup files and uses SSH to run them on the VM.
-
 4. Note the `public_ip_address` output—you'll use this to connect.
 
 
@@ -95,12 +81,7 @@ Include:
 - `terraform version`
 - `gcloud auth list --filter=status:ACTIVE` output (no secrets)
 - The exact `terraform apply` error output (redact any secrets)
-- Whether SSH fails or the issue happens after login (e.g., `verify progress`)
-- If SSH works but the lab is not ready, check `/var/log/ctf_setup.log`, `/var/lib/cloud/instance/ctf-setup.done`, `/var/lib/linux-ctfs/setup.done`, and `/var/lib/linux-ctfs/setup.failed`
-
-### Changing Setup Versions
-
-The setup script runs during first boot. If you change `setup_release_tag` after a VM already exists, or if the default `latest` release changes, recreate the VM so first-boot setup runs with the new package.
+- Whether SSH fails or the issue happens after login, such as when running `verify progress`
 
 ## Security Note
 

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}
+
 # Variables
 variable "gcp_project" {
   description = "The GCP project ID"
@@ -107,6 +116,28 @@ locals {
     touch "$${DONE_MARKER}"
     rm -f "$${FAILED_MARKER}"
     trap - ERR
+  EOF
+
+  release_readiness_script = <<-EOF
+    set -eu
+    echo "Waiting for CTF setup to finish..."
+    for attempt in $(seq 1 180); do
+      if test -f /var/lib/linux-ctfs/setup.failed; then
+        echo "CTF setup failed. Check /var/log/ctf_setup.log and /var/log/cloud-init-output.log." >&2
+        exit 1
+      fi
+
+      if test -f /var/lib/linux-ctfs/setup.done || test -f /var/lib/cloud/instance/ctf-setup.done || test -f /var/log/setup_complete; then
+        echo "CTF setup is complete."
+        exit 0
+      fi
+
+      echo "CTF setup is still running. Attempt $attempt/180."
+      sleep 10
+    done
+
+    echo "Timed out waiting for CTF setup. Check /var/log/ctf_setup.log and /var/log/cloud-init-output.log." >&2
+    exit 1
   EOF
 }
 
@@ -227,8 +258,29 @@ resource "null_resource" "local_setup" {
   }
 }
 
+resource "null_resource" "release_setup_ready" {
+  count      = var.use_local_setup ? 0 : 1
+  depends_on = [google_compute_instance.ctf_instance]
+
+  triggers = {
+    instance_id = google_compute_instance.ctf_instance.id
+  }
+
+  connection {
+    type     = "ssh"
+    host     = google_compute_instance.ctf_instance.network_interface[0].access_config[0].nat_ip
+    user     = "ctf_user"
+    password = "CTFpassword123!"
+    timeout  = "30m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [local.release_readiness_script]
+  }
+}
+
 # Output the public IP address
 output "public_ip_address" {
   value      = google_compute_instance.ctf_instance.network_interface[0].access_config[0].nat_ip
-  depends_on = [null_resource.local_setup]
+  depends_on = [null_resource.local_setup, null_resource.release_setup_ready]
 }


### PR DESCRIPTION
Add release-mode readiness checks so Terraform waits for setup markers before returning VM connection details. Simplify learner-facing provider docs to only show the commands needed to run the lab.