### PR TITLE
Add rule to enforce LF line endings for all shell scripts (#92)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Closes #92 

My Solution: Added a .gitattributes file that enforces the conversion of CRLF line endings to LF.

Test: Ran "bash -n ctf_setup.sh" to see if the .sh file parsed cleanly.

Result: The ctf_setup.sh file parsed cleanly without any errors.