### PR TITLE
Migrate cloud images to Ubuntu 24.04 LTS (#82)

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -240,7 +240,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
   }
   filter {
     name   = "virtualization-type"

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -265,8 +265,8 @@ resource "azurerm_linux_virtual_machine" "ctf_vm" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts-gen2"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
     version   = "latest"
   }
 

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -192,7 +192,7 @@ resource "google_compute_instance" "ctf_instance" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      image = "ubuntu-os-cloud/ubuntu-2404-lts"
       size  = 20
       type  = "pd-standard"
     }


### PR DESCRIPTION
Closes #82

## Summary

Migrated Terraform images from Ubuntu 22.04 LTS (Jammy) to Ubuntu 24.04 LTS (Noble) across all supported cloud providers.

## Changes

### AWS

Updated the AMI filter from:

`ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*`

to:

`ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*`

### Azure

Updated the image reference from:

- `offer = "0001-com-ubuntu-server-jammy"`
- `sku = "22_04-lts-gen2"`

to:

- `offer = "ubuntu-24_04-lts"`
- `sku = "server"`

based on Canonical Ubuntu 24.04 LTS Azure image documentation.

### GCP

Updated the image from:

`ubuntu-os-cloud/ubuntu-2204-lts`

to:

`ubuntu-os-cloud/ubuntu-2404-lts`

## Validation

### Confirmed Image Identifiers

- AWS: Canonical Ubuntu Noble 24.04 AMD64 server AMI filter
- Azure: Canonical Ubuntu 24.04 LTS image reference
- GCP: `ubuntu-os-cloud/ubuntu-2404-lts`

### AWS Validation (Manually Tested)

✅ Successfully deployed the lab using Terraform

✅ Confirmed Ubuntu 24.04.4 LTS via `/etc/os-release`

✅ Confirmed cloud-init completed successfully (`cloud-init status: done`)

✅ Verified SSH access

✅ Verified `verify progress`

✅ Verified `verify list`

✅ Verified DNS challenge behavior

✅ Verified Cron challenge behavior

✅ Verified Nginx/Web Configuration challenge behavior

✅ Verified Service Discovery challenge (`ctf-secret-service.service` running and accessible)

✅ Verified network service accessibility

✅ Verified certificate export command functionality

### Unable to Validate

❌ Azure — unable to validate due to lack of an active Azure subscription

❌ GCP — unable to validate due to lack of an active GCP project with billing enabled

## Documentation

No README updates were required because deployment, setup, usage, and troubleshooting instructions remain unchanged. The image updates are internal Terraform configuration changes only.

## Notes

- No provider-specific issues were encountered during AWS validation.
- This change is limited to Ubuntu image upgrades and remains separate from the Python refactor work tracked in #81.
- Manual cloud deployment and validation were completed on AWS as required by the issue.