### PR TITLE
fix: normalize ctf_setup.sh to LF line endings and add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for shell scripts
+*.sh text eol=lf
+ctf_setup.sh text eol=lf


### PR DESCRIPTION
## What I did
- Fixed CRLF line endings in `ctf_setup.sh` (converted to LF)
- Added `.gitattributes` rule to prevent this issue in the future for all shell scripts

## Why
This resolves the shell script validation failures on Linux when the repo is cloned on Windows.

## Testing
- `bash -n ctf_setup.sh` → passes
- `shellcheck -S warning ctf_setup.sh` → clean

Fixes #92  
Related to discussion #521