### PR TITLE
Fix GCP Ubuntu 24.04 image family for Terraform lab

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -198,7 +198,7 @@ resource "google_compute_instance" "ctf_instance" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-2404-lts"
+      image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
       size  = 20
       type  = "pd-standard"
     }


### PR DESCRIPTION
Fixes GCP Terraform lab failure caused by an invalid Ubuntu 24.04 image family reference.