### PR TITLE
fix(gcp): restore Ubuntu image family reference

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -198,7 +198,7 @@ resource "google_compute_instance" "ctf_instance" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/family/ubuntu-2404-lts-amd64"
+      image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
       size  = 20
       type  = "pd-standard"
     }


### PR DESCRIPTION
Reverts the GCP Ubuntu image reference change from the recent PR so the Terraform lab uses the known-good `ubuntu-os-cloud/ubuntu-2404-lts-amd64` image reference again.

This restores the fix previously landed in #110.