### PR TITLE
ci: harden shellcheck and release-setup workflows

### DIFF
--- a/.github/workflows/release-setup.yml
+++ b/.github/workflows/release-setup.yml
@@ -27,7 +27,7 @@ jobs:
           fi
 
       - name: Check out release code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.release.outputs.tag }}
 
@@ -41,6 +41,9 @@ jobs:
             --group=0 \
             --numeric-owner \
             --mtime="UTC 1970-01-01" \
+            --exclude='__pycache__' \
+            --exclude='*.pyc' \
+            --exclude='.venv' \
             -cf - ctf_setup.sh setup verify | gzip -n > "$asset"
           sha256sum "$asset" > "$asset.sha256"
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,14 +17,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: '.'
           severity: warning
           ignore_paths: >-
             .terraform
-        env:
-          SHELLCHECK_OPTS: -e SC1091 -e SC2086


### PR DESCRIPTION
## Summary

Hardening pass on the two CI workflows after a review.

### `shellcheck.yml`
- Pin `ludeeus/action-shellcheck` to its `2.0.0` commit SHA (was `@master` — unpinned supply-chain risk).
- Pin `actions/checkout` to its `v4` commit SHA.
- Remove the global `SHELLCHECK_OPTS: -e SC1091 -e SC2086`:
  - **SC2086** (unquoted-variable word-splitting/globbing) is a genuine correctness/safety check; disabling it repo-wide removed the guardrail for future edits. The current scripts already quote properly, so re-enabling is low-risk.
  - **SC1091** (can't follow sourced file) had nothing to act on — no script uses `source`/`.` — so it was an effective no-op.

### `release-setup.yml`
- Pin `actions/checkout` to its `v4` commit SHA.
- Add `--exclude` flags (`__pycache__`, `*.pyc`, `.venv`) to the release `tar` so the published `linux-ctfs-setup.tar.gz` is byte-identical to the Terraform local build and never ships stray Python cache.

## Notes
- `.terraform` remains excluded from ShellCheck (Terraform-generated/vendored dir + local build artifacts).
- No behavior change to the release flow itself; it still runs on `release: published` and manual `workflow_dispatch` with a tag input.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>