### PR TITLE
docs: improve Azure VM capacity troubleshooting flow

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -7,6 +7,8 @@ This guide shows examples of errors you might see when deploying the linux-ctfs 
 - [AWS: Quota / vCPU limit errors](#aws-quota--vcpu-limit-errors)
 - [AWS: Service Control Policy (SCP) / Explicit deny errors](#aws-service-control-policy-scp--explicit-deny-errors)
 - [Azure](#azure)
+- [Azure: SkuNotAvailable / Capacity errors](#azure-skunotavailable--capacity-errors)
+- [Azure: Quota limit errors](#azure-quota-limit-errors)
 - [GCP](#gcp)
 
 ## AWS
@@ -108,7 +110,74 @@ terraform apply \
 
 ## Azure
 
-(Coming soon) - common deployment issues and how to adjust `azure_vm_size`.
+The Terraform commands in this Azure section assume you are running them from the `azure/` directory.
+
+The default VM size is `Standard_B1s`, and the default region is `East US`.
+
+### Azure: SkuNotAvailable / Capacity errors
+
+If Terraform fails with an error like:
+
+```text
+SkuNotAvailable: The requested VM size ... is currently not available in location "your location"
+```
+
+This usually means the selected region does not currently have capacity for that SKU, or your subscription is restricted in that region.
+
+Check whether `Standard_B1s` is available in a region:
+
+```sh
+az vm list-skus \
+  --location eastus \
+  --resource-type virtualMachines \
+  --size Standard_B1s \
+  --all \
+  --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
+  -o json
+```
+
+If `restrictions` is `[]`, the SKU is available for your subscription in that region. If restrictions are returned, switch region and retry.
+
+To quickly compare common regions:
+
+```sh
+for region in eastus southcentralus westus; do
+  echo "== $region =="
+  az vm list-skus \
+    --location "$region" \
+    --resource-type virtualMachines \
+    --size Standard_B1s \
+    --all \
+    --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
+    -o json
+done
+```
+
+### Azure: Quota limit errors
+
+If the SKU is available but deployment still fails, check VM usage/quota in the target region:
+
+```sh
+az vm list-usage --location eastus -o table
+```
+
+If usage is near the limit, either use another region or choose a different VM size.
+
+Retry with a different region:
+
+```sh
+terraform apply \
+  -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
+  -var az_region="southcentralus"
+```
+
+Or retry with a different VM size:
+
+```sh
+terraform apply \
+  -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
+  -var azure_vm_size="Standard_B1ms"
+```
 
 ## GCP
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -39,6 +39,60 @@ az login
 
     If you run into errors when deploying, see [TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for common issues and fixes.
 
+### VM Size / Capacity Errors
+
+If you encounter an error like:
+
+```text
+SkuNotAvailable: The requested VM size ... is currently not available in location "your location"
+```
+
+This is usually due to regional capacity restrictions, subscription limits, or VM quota in the selected region. The default VM size is `Standard_B1s`, and the default region is `East US`.
+
+Check whether `Standard_B1s` is available in a region:
+
+```sh
+az vm list-skus \
+  --location eastus \
+  --resource-type virtualMachines \
+  --size Standard_B1s \
+  --all \
+  --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
+  -o json
+```
+
+If `restrictions` is `[]`, Azure reports that SKU as available for your subscription in that region. If restrictions are returned, try another region or VM size.
+
+Check VM quota in a region:
+
+```sh
+az vm list-usage --location eastus -o table
+```
+
+To check several common regions:
+
+```sh
+for region in eastus southcentralus westus; do
+  echo "== $region =="
+  az vm list-skus \
+    --location "$region" \
+    --resource-type virtualMachines \
+    --size Standard_B1s \
+    --all \
+    --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
+    -o json
+  az vm list-usage --location "$region" -o table
+done
+```
+
+If your selected region is restricted, retry with a known available region:
+
+```sh
+terraform apply \
+  -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
+  -var az_region="eastus"
+```
+
 4. Note the `public_ip_address` output—you'll use this to connect.
 
 ## Accessing the Lab
@@ -116,60 +170,6 @@ Include:
 - `az account show` output (no secrets)
 - The exact `terraform apply` error output (redact any secrets)
 - Whether SSH fails or the issue happens after login, such as when running `verify progress`
-
-### VM Size / Capacity Errors
-
-If you encounter an error like:
-
-```text
-SkuNotAvailable: The requested VM size ... is currently not available in location "your location"
-```
-
-This is usually due to regional capacity restrictions, subscription limits, or VM quota in the selected region. The default VM size is `Standard_B1s`, and the default region is `East US`.
-
-Check whether `Standard_B1s` is available in a region:
-
-```sh
-az vm list-skus \
-  --location eastus \
-  --resource-type virtualMachines \
-  --size Standard_B1s \
-  --all \
-  --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
-  -o json
-```
-
-If `restrictions` is `[]`, Azure reports that SKU as available for your subscription in that region. If restrictions are returned, try another region or VM size.
-
-Check VM quota in a region:
-
-```sh
-az vm list-usage --location eastus -o table
-```
-
-To check several common regions:
-
-```sh
-for region in eastus southcentralus westus; do
-  echo "== $region =="
-  az vm list-skus \
-    --location "$region" \
-    --resource-type virtualMachines \
-    --size Standard_B1s \
-    --all \
-    --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
-    -o json
-  az vm list-usage --location "$region" -o table
-done
-```
-
-If your selected region is restricted, retry with a known available region:
-
-```sh
-terraform apply \
-  -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
-  -var az_region="eastus"
-```
 
 ## Security Note
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -41,57 +41,15 @@ az login
 
 ### VM Size / Capacity Errors
 
-If you encounter an error like:
+If `terraform apply` fails with `SkuNotAvailable` or quota/capacity errors, the fastest fix is usually switching region and/or VM size.
 
-```text
-SkuNotAvailable: The requested VM size ... is currently not available in location "your location"
-```
+Defaults for this lab:
+- Region: `East US` (`az_region`)
+- VM size: `Standard_B1s` (`azure_vm_size`)
 
-This is usually due to regional capacity restrictions, subscription limits, or VM quota in the selected region. The default VM size is `Standard_B1s`, and the default region is `East US`.
-
-Check whether `Standard_B1s` is available in a region:
-
-```sh
-az vm list-skus \
-  --location eastus \
-  --resource-type virtualMachines \
-  --size Standard_B1s \
-  --all \
-  --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
-  -o json
-```
-
-If `restrictions` is `[]`, Azure reports that SKU as available for your subscription in that region. If restrictions are returned, try another region or VM size.
-
-Check VM quota in a region:
-
-```sh
-az vm list-usage --location eastus -o table
-```
-
-To check several common regions:
-
-```sh
-for region in eastus southcentralus westus; do
-  echo "== $region =="
-  az vm list-skus \
-    --location "$region" \
-    --resource-type virtualMachines \
-    --size Standard_B1s \
-    --all \
-    --query "[?name=='Standard_B1s'].{name:name, restrictions:restrictions}" \
-    -o json
-  az vm list-usage --location "$region" -o table
-done
-```
-
-If your selected region is restricted, retry with a known available region:
-
-```sh
-terraform apply \
-  -var subscription_id="YOUR_AZURE_SUBSCRIPTION_ID" \
-  -var az_region="eastus"
-```
+Use the full Azure troubleshooting steps here:
+- [Azure: SkuNotAvailable / Capacity errors](../TROUBLESHOOTING.md#azure-skunotavailable--capacity-errors)
+- [Azure: Quota limit errors](../TROUBLESHOOTING.md#azure-quota-limit-errors)
 
 4. Note the `public_ip_address` output—you'll use this to connect.
 


### PR DESCRIPTION
## Why
Azure learners can hit SKU capacity or quota errors during first deploy, and the troubleshooting guidance was either too late in the flow or missing from the shared troubleshooting guide.

## What changed
- Moved Azure VM capacity guidance earlier in `azure/README.md` so it appears right after the initial `terraform apply` instructions.
- Reduced duplication by keeping that README section concise and pointing to the detailed troubleshooting reference.
- Replaced the Azure placeholder in `TROUBLESHOOTING.md` with actionable guidance for:
  - `SkuNotAvailable` and regional capacity restrictions
  - regional quota/usage limits
- Added practical Azure CLI commands to check SKU availability (`az vm list-skus`) and quota usage (`az vm list-usage`), plus clear next steps to switch region and/or VM size.

## Notes
- Guidance is aligned with current defaults: `az_region` default `East US`, `azure_vm_size` default `Standard_B1s`.
- This change is documentation-only.