### PR TITLE
Enhance AWS SSM integration and update troubleshooting guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,8 @@ Most contributors only need to know this:
 Setup readiness differs by provider:
 
 - Azure release mode uses VM Custom Script Extension (Terraform 1.14.0 or newer), so Terraform waits for extension success or failure.
-- AWS and GCP release mode still use the shared SSH marker wait.
+- AWS release mode uses Systems Manager Run Command to run the shared marker readiness check.
+- GCP release mode still uses the shared SSH marker wait.
 - Contributor mode stays on `use_local_setup=true`, uploading local files over SSH for test runs.
 
 If you manually run Terraform to test local setup changes, pass:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Most contributors only need to know this:
 Setup readiness differs by provider:
 
 - Azure release mode uses VM Custom Script Extension (Terraform 1.14.0 or newer), so Terraform waits for extension success or failure.
-- AWS release mode uses Systems Manager Run Command to run the shared marker readiness check.
+- AWS release mode uses Systems Manager Run Command to run the shared marker readiness check. Windows users must run this deployment path from WSL because the local readiness helper requires `/bin/sh`.
 - GCP release mode still uses the shared SSH marker wait.
 - Contributor mode stays on `use_local_setup=true`, uploading local files over SSH for test runs.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -5,6 +5,7 @@ This guide shows examples of errors you might see when deploying the linux-ctfs 
 - [AWS](#aws)
 - [AWS: Region / endpoint / Auth errors](#aws-region--endpoint--auth-errors)
 - [AWS: Quota / vCPU limit errors](#aws-quota--vcpu-limit-errors)
+- [AWS: SSM setup readiness errors](#aws-ssm-setup-readiness-errors)
 - [AWS: Service Control Policy (SCP) / Explicit deny errors](#aws-service-control-policy-scp--explicit-deny-errors)
 - [Azure](#azure)
 - [GCP](#gcp)
@@ -82,6 +83,34 @@ terraform apply -var="aws_instance_type=t3.micro"
 ```
 
 If you need a larger size, you can request a quota increase in the AWS console for the region you want to use.
+
+### AWS: SSM setup readiness errors
+
+AWS release mode uses Systems Manager to wait for setup readiness. If Terraform fails while waiting on `null_resource.release_setup_ready`, check whether the instance became an SSM managed node and whether the SSM Run Command completed.
+
+Useful checks:
+
+```sh
+aws ssm describe-instance-information \
+  --region us-east-1 \
+  --filters Key=InstanceIds,Values=<instance_id>
+```
+
+```sh
+aws ssm list-command-invocations \
+  --region us-east-1 \
+  --instance-id <instance_id> \
+  --details
+```
+
+Common causes:
+
+- The Terraform caller cannot create IAM roles, IAM instance profiles, or send/read SSM commands.
+- The generated SSM instance profile is not attached to the EC2 instance.
+- SSM Agent is not running yet on the VM.
+- Account-level SSM maintenance commands are still running during first boot.
+- The instance cannot reach Systems Manager endpoints over outbound HTTPS.
+- Setup failed before writing `/var/lib/linux-ctfs/setup.done`; check `/var/log/cloud-init-output.log` and `/var/log/ctf_setup.log`.
 
 ### AWS: Service Control Policy (SCP) / Explicit deny errors
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -16,6 +16,14 @@ This guide shows examples of errors you might see when deploying the linux-ctfs 
 
 The Terraform commands in this AWS section assume you are running them from the `aws/` directory.
 
+On Windows, run the AWS deployment from WSL. The release-mode Systems Manager readiness check requires `/bin/sh` and is not supported from native PowerShell or Command Prompt. Install Terraform and the AWS CLI inside WSL, then confirm that WSL can access your AWS credentials:
+
+```sh
+aws sts get-caller-identity
+```
+
+If AWS CLI works in Windows but not in WSL, configure credentials inside WSL with `aws configure`.
+
 Before your first AWS deploy, list the regions that are enabled for your account:
 
 ```sh
@@ -105,6 +113,7 @@ aws ssm list-command-invocations \
 
 Common causes:
 
+- Terraform is running from native Windows PowerShell or Command Prompt instead of WSL.
 - The Terraform caller cannot create IAM roles, IAM instance profiles, or send/read SSM commands.
 - The generated SSM instance profile is not attached to the EC2 instance.
 - SSM Agent is not running yet on the VM.

--- a/aws/README.md
+++ b/aws/README.md
@@ -118,7 +118,7 @@ Type `yes` when prompted.
 
 1. Ensure your AWS CLI is configured with valid credentials
 2. Check that you're using Terraform v1.9.0 or later
-3. Verify you have permissions to create EC2, VPC, and Security Group resources
+3. Verify you have permissions to create EC2, VPC, Security Group, IAM role/profile, and SSM Run Command resources
 
 If problems persist, please open an issue:
 
@@ -130,6 +130,19 @@ Include:
 - `aws sts get-caller-identity` output (no secrets)
 - The exact `terraform apply` error output (redact any secrets)
 - Whether SSH fails or the issue happens after login, such as when running `verify progress`
+
+### Release Setup Readiness
+
+AWS release mode uses Systems Manager to wait for setup readiness. Terraform creates an EC2 instance profile with `AmazonSSMManagedInstanceCore`, lets the VM run setup through `user_data`, then sends an SSM Run Command to confirm the setup marker files.
+
+If `terraform apply` fails while waiting for readiness, check:
+
+- The EC2 instance has the generated SSM instance profile attached.
+- The instance is listed as a Systems Manager managed node.
+- Outbound HTTPS is allowed so SSM Agent can reach Systems Manager endpoints.
+- SSM Agent is running on the VM.
+- The AWS CLI can call `ssm:DescribeInstanceInformation`, `ssm:SendCommand`, and `ssm:GetCommandInvocation`.
+- VM logs: `/var/log/cloud-init-output.log` and `/var/log/ctf_setup.log`.
 
 ## Security Note
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -5,6 +5,19 @@
 1. [Terraform](https://www.terraform.io/downloads.html) (v1.9.0 or later)
 2. [AWS CLI](https://aws.amazon.com/cli/) configured with your credentials
 
+### Windows
+
+Run the AWS Terraform deployment from [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/windows/wsl/install). AWS release-mode readiness uses a local `/bin/sh` script to wait for Systems Manager Run Command, so native Windows PowerShell and Command Prompt are not currently supported.
+
+Install Terraform and the AWS CLI inside your WSL distribution, then configure AWS credentials there before following the steps below:
+
+```sh
+aws configure
+aws sts get-caller-identity
+```
+
+Credentials configured only in Windows PowerShell are not automatically available inside WSL.
+
 ## Getting Started
 
 1. Clone this repository:
@@ -141,7 +154,7 @@ If `terraform apply` fails while waiting for readiness, check:
 - The instance is listed as a Systems Manager managed node.
 - Outbound HTTPS is allowed so SSM Agent can reach Systems Manager endpoints.
 - SSM Agent is running on the VM.
-- The AWS CLI can call `ssm:DescribeInstanceInformation`, `ssm:SendCommand`, and `ssm:GetCommandInvocation`.
+- The AWS CLI can call `ssm:DescribeInstanceInformation`, `ssm:ListCommandInvocations`, `ssm:SendCommand`, and `ssm:GetCommandInvocation`.
 - VM logs: `/var/log/cloud-init-output.log` and `/var/log/ctf_setup.log`.
 
 ## Security Note

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -272,7 +272,7 @@ data "aws_iam_policy_document" "ctf_ssm_assume_role" {
 resource "aws_iam_role" "ctf_ssm" {
   count = var.use_local_setup ? 0 : 1
 
-  name               = "linux-ctfs-ssm-${var.aws_region}"
+  name_prefix        = "linux-ctfs-ssm-${var.aws_region}-"
   assume_role_policy = data.aws_iam_policy_document.ctf_ssm_assume_role[0].json
 
   tags = {
@@ -290,8 +290,8 @@ resource "aws_iam_role_policy_attachment" "ctf_ssm_managed_instance_core" {
 resource "aws_iam_instance_profile" "ctf_ssm" {
   count = var.use_local_setup ? 0 : 1
 
-  name = "linux-ctfs-ssm-${var.aws_region}"
-  role = aws_iam_role.ctf_ssm[0].name
+  name_prefix = "linux-ctfs-ssm-${var.aws_region}-"
+  role        = aws_iam_role.ctf_ssm[0].name
 
   tags = {
     Name = "CTF Lab SSM Instance Profile"

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -256,6 +256,48 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
+data "aws_iam_policy_document" "ctf_ssm_assume_role" {
+  count = var.use_local_setup ? 0 : 1
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ctf_ssm" {
+  count = var.use_local_setup ? 0 : 1
+
+  name               = "linux-ctfs-ssm-${var.aws_region}"
+  assume_role_policy = data.aws_iam_policy_document.ctf_ssm_assume_role[0].json
+
+  tags = {
+    Name = "CTF Lab SSM Role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ctf_ssm_managed_instance_core" {
+  count = var.use_local_setup ? 0 : 1
+
+  role       = aws_iam_role.ctf_ssm[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ctf_ssm" {
+  count = var.use_local_setup ? 0 : 1
+
+  name = "linux-ctfs-ssm-${var.aws_region}"
+  role = aws_iam_role.ctf_ssm[0].name
+
+  tags = {
+    Name = "CTF Lab SSM Instance Profile"
+  }
+}
+
 resource "aws_instance" "ctf_instance" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = var.aws_instance_type
@@ -264,9 +306,12 @@ resource "aws_instance" "ctf_instance" {
   subnet_id              = aws_subnet.ctf_subnet.id
 
   associate_public_ip_address = true
+  iam_instance_profile        = var.use_local_setup ? null : aws_iam_instance_profile.ctf_ssm[0].name
 
   user_data                   = var.use_local_setup ? local.local_bootstrap_script : local.release_setup_script
   user_data_replace_on_change = true
+
+  depends_on = [aws_iam_role_policy_attachment.ctf_ssm_managed_instance_core]
 
   tags = {
     Name = "CTF Lab Instance"
@@ -315,20 +360,125 @@ resource "null_resource" "release_setup_ready" {
   depends_on = [aws_instance.ctf_instance]
 
   triggers = {
-    instance_id = aws_instance.ctf_instance.id
+    instance_id              = aws_instance.ctf_instance.id
+    release_readiness_script = sha256(local.release_readiness_script)
   }
 
-  connection {
-    type     = "ssh"
-    host     = aws_instance.ctf_instance.public_ip
-    user     = "ctf_user"
-    password = "CTFpassword123!"
-    timeout  = "30m"
-  }
+  provisioner "local-exec" {
+    interpreter = ["/bin/sh", "-c"]
+    command = <<-EOF
+      set -eu
+      instance_id='${aws_instance.ctf_instance.id}'
+      region='${var.aws_region}'
+      command_file='${path.module}/.terraform/linux-ctfs-ssm-readiness-command.json'
 
-  provisioner "remote-exec" {
-    inline = [local.release_readiness_script]
-  }
+      echo "Waiting for ${aws_instance.ctf_instance.id} to register with Systems Manager..."
+      for attempt in $(seq 1 60); do
+        ping_status=$(aws ssm describe-instance-information \
+          --region "$region" \
+          --filters "Key=InstanceIds,Values=$instance_id" \
+          --query 'InstanceInformationList[0].PingStatus' \
+          --output text 2>/dev/null || true)
+
+        if [ "$ping_status" = "Online" ]; then
+          echo "Systems Manager managed node is online."
+          break
+        fi
+
+        if [ "$attempt" -eq 60 ]; then
+          echo "Timed out waiting for Systems Manager managed node registration." >&2
+          exit 1
+        fi
+
+        echo "Systems Manager managed node is not ready yet. Attempt $attempt/60."
+        sleep 10
+      done
+
+      echo "Waiting for startup Systems Manager commands to settle..."
+      quiet_checks=0
+      for attempt in $(seq 1 60); do
+        active_commands=$(aws ssm list-command-invocations \
+          --region "$region" \
+          --instance-id "$instance_id" \
+          --query "length(CommandInvocations[?Status=='Pending' || Status=='InProgress' || Status=='Delayed'])" \
+          --output text 2>/dev/null || echo 0)
+
+        if [ "$active_commands" = "0" ]; then
+          quiet_checks=$((quiet_checks + 1))
+          if [ "$quiet_checks" -ge 3 ]; then
+            echo "Systems Manager command queue is clear."
+            break
+          fi
+        else
+          quiet_checks=0
+          echo "Systems Manager has $active_commands active command(s). Attempt $attempt/60."
+        fi
+
+        if [ "$attempt" -eq 60 ]; then
+          echo "Timed out waiting for startup Systems Manager commands to settle." >&2
+          exit 1
+        fi
+
+        sleep 10
+      done
+
+      mkdir -p '${path.module}/.terraform'
+      cat > "$command_file" <<'JSON'
+${jsonencode({
+    DocumentName   = "AWS-RunShellScript"
+    InstanceIds    = [aws_instance.ctf_instance.id]
+    Comment        = "Wait for Linux CTF setup readiness"
+    TimeoutSeconds = 1800
+    Parameters = {
+      commands = [local.release_readiness_script]
+    }
+})}
+JSON
+
+      command_id=$(aws ssm send-command \
+        --region "$region" \
+        --cli-input-json "file://$command_file" \
+        --query 'Command.CommandId' \
+        --output text)
+
+      echo "Waiting for SSM command $command_id to report setup readiness..."
+      for attempt in $(seq 1 180); do
+        status=$(aws ssm get-command-invocation \
+          --region "$region" \
+          --command-id "$command_id" \
+          --instance-id "$instance_id" \
+          --query 'Status' \
+          --output text 2>/dev/null || true)
+
+        case "$status" in
+          Success)
+            aws ssm get-command-invocation \
+              --region "$region" \
+              --command-id "$command_id" \
+              --instance-id "$instance_id" \
+              --query '{Status:Status,ResponseCode:ResponseCode,StandardOutputContent:StandardOutputContent,StandardErrorContent:StandardErrorContent}' \
+              --output json
+            exit 0
+            ;;
+          Failed|Cancelled|TimedOut|Cancelling)
+            aws ssm get-command-invocation \
+              --region "$region" \
+              --command-id "$command_id" \
+              --instance-id "$instance_id" \
+              --query '{Status:Status,ResponseCode:ResponseCode,StandardOutputContent:StandardOutputContent,StandardErrorContent:StandardErrorContent}' \
+              --output json >&2
+            exit 1
+            ;;
+        esac
+
+        echo "SSM command status is $status. Attempt $attempt/180."
+        sleep 10
+      done
+
+      echo "Timed out waiting for SSM command $command_id to complete." >&2
+      exit 1
+    EOF
+}
 }
 
 # Output the public IP of the instance

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -372,13 +372,19 @@ resource "null_resource" "release_setup_ready" {
       region='${var.aws_region}'
       command_file='${path.module}/.terraform/linux-ctfs-ssm-readiness-command.json'
 
+      echo "Checking local AWS CLI credentials..."
+      aws sts get-caller-identity --region "$region" >/dev/null
+
       echo "Waiting for ${aws_instance.ctf_instance.id} to register with Systems Manager..."
       for attempt in $(seq 1 60); do
-        ping_status=$(aws ssm describe-instance-information \
-          --region "$region" \
-          --filters "Key=InstanceIds,Values=$instance_id" \
-          --query 'InstanceInformationList[0].PingStatus' \
-          --output text 2>/dev/null || true)
+        if ! ping_status=$(aws ssm describe-instance-information \
+            --region "$region" \
+            --filters "Key=InstanceIds,Values=$instance_id" \
+            --query 'InstanceInformationList[0].PingStatus' \
+            --output text); then
+          echo "Failed to query Systems Manager managed-node registration." >&2
+          exit 1
+        fi
 
         if [ "$ping_status" = "Online" ]; then
           echo "Systems Manager managed node is online."
@@ -397,11 +403,14 @@ resource "null_resource" "release_setup_ready" {
       echo "Waiting for startup Systems Manager commands to settle..."
       quiet_checks=0
       for attempt in $(seq 1 60); do
-        active_commands=$(aws ssm list-command-invocations \
-          --region "$region" \
-          --instance-id "$instance_id" \
-          --query "length(CommandInvocations[?Status=='Pending' || Status=='InProgress' || Status=='Delayed'])" \
-          --output text 2>/dev/null || echo 0)
+        if ! active_commands=$(aws ssm list-command-invocations \
+            --region "$region" \
+            --instance-id "$instance_id" \
+            --query "length(CommandInvocations[?Status=='Pending' || Status=='InProgress' || Status=='Delayed'])" \
+            --output text); then
+          echo "Failed to query Systems Manager command activity." >&2
+          exit 1
+        fi
 
         if [ "$active_commands" = "0" ]; then
           quiet_checks=$((quiet_checks + 1))
@@ -443,12 +452,25 @@ JSON
 
       echo "Waiting for SSM command $command_id to report setup readiness..."
       for attempt in $(seq 1 180); do
-        status=$(aws ssm get-command-invocation \
-          --region "$region" \
-          --command-id "$command_id" \
-          --instance-id "$instance_id" \
-          --query 'Status' \
-          --output text 2>/dev/null || true)
+        if ! invocation_result=$(aws ssm get-command-invocation \
+            --region "$region" \
+            --command-id "$command_id" \
+            --instance-id "$instance_id" \
+            --query 'Status' \
+            --output text 2>&1); then
+          case "$invocation_result" in
+            *InvocationDoesNotExist*)
+              status="Pending"
+              ;;
+            *)
+              echo "$invocation_result" >&2
+              echo "Failed to query SSM command invocation status." >&2
+              exit 1
+              ;;
+          esac
+        else
+          status="$invocation_result"
+        fi
 
         case "$status" in
           Success)


### PR DESCRIPTION
This pull request updates the AWS deployment process to use AWS Systems Manager (SSM) Run Command for release-mode setup readiness, replacing the previous SSH-based readiness check. It also adds new IAM resources for SSM, improves documentation for Windows users (requiring WSL), and provides troubleshooting steps for SSM-related issues.

**AWS Release Mode Setup Readiness via SSM:**

- Added new IAM resources in `aws/main.tf` to create an EC2 instance profile with the `AmazonSSMManagedInstanceCore` policy, enabling the instance to register as an SSM managed node.
- Updated the `aws_instance` resource to attach the SSM instance profile when not in local setup mode.
- Replaced the SSH-based readiness check in the `release_setup_ready` resource with a `local-exec` provisioner that waits for SSM registration and uses SSM Run Command to check setup readiness.

**Documentation and Troubleshooting Improvements:**

- Updated `aws/README.md` and `CONTRIBUTING.md` to explain the new SSM-based readiness check, required permissions, and the need for WSL on Windows. [[1]](diffhunk://#diff-d1f3cfb2cd1f80df61fb16ed5304cf357114bed4c6b1a8a57a155328c5f581f7R8-R20) [[2]](diffhunk://#diff-d1f3cfb2cd1f80df61fb16ed5304cf357114bed4c6b1a8a57a155328c5f581f7L121-R134) [[3]](diffhunk://#diff-d1f3cfb2cd1f80df61fb16ed5304cf357114bed4c6b1a8a57a155328c5f581f7R147-R159) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L126-R127)
- Added troubleshooting steps and a new section for SSM setup readiness errors in `TROUBLESHOOTING.md`, including common causes and diagnostic commands. [[1]](diffhunk://#diff-04b06f404cedd4fe55417bf2feb76031f0de972056a26f540e8eb878d7d3b81eR8) [[2]](diffhunk://#diff-04b06f404cedd4fe55417bf2feb76031f0de972056a26f540e8eb878d7d3b81eR19-R26) [[3]](diffhunk://#diff-04b06f404cedd4fe55417bf2feb76031f0de972056a26f540e8eb878d7d3b81eR95-R123)

These changes ensure more robust and cloud-native setup readiness checks for AWS deployments and provide clearer guidance for contributors and users.