### PR TITLE
Fix verify export token wrapping on narrow terminals (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Some terminals truncate long lines when copying. If your token isn't being accep
    ```bash
    nano ~/token.txt
    ```
-   `nano` will word-wrap properly. Does it match what you see in terminal? If it's longer in `nano`, your terminal was truncating it — use the full value from `nano`.
+   `nano` will word-wrap properly. Does it match what you see in terminal? If it's longer in `nano`, your terminal was truncating it, so use the full value from `nano`.
 
 4. **Still not working?** Open a [GitHub issue](https://github.com/learntocloud/linux-ctfs/issues) with the output of `wc -c ~/token.txt`.
 

--- a/verify/src/verify/commands.py
+++ b/verify/src/verify/commands.py
@@ -299,7 +299,7 @@ def export_certificate(state: CtfState, github_username: str | None) -> int:
     console.print("  3. Paste the token below")
     console.print("")
     console.print("--- BEGIN L2C CTF TOKEN ---")
-    console.print(token)
+    console.print(token, soft_wrap=True)
     console.print("--- END L2C CTF TOKEN ---")
     console.print("")
     return 0


### PR DESCRIPTION
## Problem

Fixes #121. `verify export` prints the ~328-char base64 completion token via `console.print(token)`. Rich's `Console.print()` inserts a **literal** newline to wrap output that exceeds the terminal width, embedding a real `\n` inside the token on narrow terminals (common in default SSH sessions). learntocloud.guide then rejects the token with "Invalid token format. Could not decode the token."

## Fix

Print the token with `soft_wrap=True` so it is always emitted as a single line regardless of terminal width.

```diff
-    console.print(token)
+    console.print(token, soft_wrap=True)
```

## Verification

At width 80, the old call produced 4 embedded newlines; with `soft_wrap=True` the token prints with 0 newlines and the full 328-char length preserved. Confirmed line 302 is the only place that prints the raw token.

## Notes

- No change to token content, signing, or format, only how it is rendered.
- Also softened wrapping-specific wording in the README token troubleshooting section.
- A companion defense-in-depth fix (stripping embedded whitespace before decoding) landed app-side, but the wrapping is fixed here at the source.